### PR TITLE
サーバーの起動後の処理に関する変更 +α

### DIFF
--- a/SMFB_BukkitBridge/src/main/java/com/github/nova_27/mcplugin/servermanager/bukkit/Smfb_bukkitbridge.java
+++ b/SMFB_BukkitBridge/src/main/java/com/github/nova_27/mcplugin/servermanager/bukkit/Smfb_bukkitbridge.java
@@ -74,7 +74,7 @@ public final class Smfb_bukkitbridge extends JavaPlugin implements PacketEventLi
         if(connectionThread != null) {
             connectionThread.stopSocket();
             try {
-                connectionThread.join();
+                connectionThread.join(5000);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/SMFB_BukkitBridge/src/main/java/com/github/nova_27/mcplugin/servermanager/bukkit/Smfb_bukkitbridge.java
+++ b/SMFB_BukkitBridge/src/main/java/com/github/nova_27/mcplugin/servermanager/bukkit/Smfb_bukkitbridge.java
@@ -59,9 +59,11 @@ public final class Smfb_bukkitbridge extends JavaPlugin implements PacketEventLi
             return;
         }
 
-        //スレッドを開始する
+        //接続スレッドを初期化する
         connectionThread = new ConnectionThread(socket, this);
-        connectionThread.start();
+
+        // 起動が完了したらスレッドを開始する (起動完了と見なす)
+        getServer().getScheduler().runTask(this, () -> connectionThread.start());
 
         //リスナーの登録
         getServer().getPluginManager().registerEvents(new SpigotListener(), this);

--- a/SMFB_Core/src/main/java/com/github/nova_27/mcplugin/servermanager/core/Smfb_core.java
+++ b/SMFB_Core/src/main/java/com/github/nova_27/mcplugin/servermanager/core/Smfb_core.java
@@ -15,6 +15,7 @@ import com.github.nova_27.mcplugin.servermanager.core.utils.Messages;
 import com.github.nova_27.mcplugin.servermanager.core.utils.Tools;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.minecrell.serverlistplus.bungee.BungeePlugin;
 import net.minecrell.serverlistplus.core.ServerListPlusCore;
@@ -194,6 +195,12 @@ public final class Smfb_core extends Plugin implements PacketEventListener {
 
         log(Tools.Formatter(Messages.ServerStarted_log.toString(), srcServer.Name));
         ProxyServer.getInstance().broadcast(new TextComponent(Tools.Formatter(Messages.ServerStarted_minecraft.toString(), srcServer.Name)));
+
+        // 起動完了かつプレイヤーが未参加であれば停止タイマーを開始する
+        ServerInfo bungeeServerInfo = getProxy().getServerInfo(srcServer.ID);
+        if (bungeeServerInfo != null && bungeeServerInfo.getPlayers().isEmpty())
+            srcServer.StartTimer();
+
         Smfb_core.getInstance().getProxy().getPluginManager().callEvent(new ServerEvent(srcServer, ServerEvent.EventType.ServerStarted));
     }
 


### PR DESCRIPTION
## 変更点
- サーバーの起動が完了したら、停止タイマーを開始させる。
※ 起動後に誰かが一度接続しないと、起動したままになるので追加。

- サーバーが完全に起動してから起動完了とみなす。
※ Bukkit側クライアントが接続したことで完了になる実装だったので、通信スレッドの開始を遅らせることで仮対応させています。

- Bukkit側 通信スレッドの停止を待機する時間を無限待機から5秒に変更
※ 何らかの理由で通信スレッドを停止できずに待機し続け、サーバーの停止処理を正常に終了できなくなることが時々ありました。